### PR TITLE
make x-ogc-linkTemplate more clearer

### DIFF
--- a/standard/requirements/discovery/REQ_links-from-openapi-to-asyncapi.adoc
+++ b/standard/requirements/discovery/REQ_links-from-openapi-to-asyncapi.adoc
@@ -3,5 +3,5 @@
 ====
 [%metadata]
 identifier:: /req/discovery/links-from-openapi-to-asyncapi
-part:: To link to a Pub/Sub channel with a channel address expression from an OpenAPI document, an ``x-ogc-linkTemplate`` object SHALL structure an OGC API - Records ``uriTemplate`` property to reference the AsyncAPI document (in JSON or YAML) with a URI template.
+part:: To link to a Pub/Sub channel with a channel address expression from an OpenAPI document, an ``x-ogc-linkTemplate`` object SHALL structure an OGC API - Records ``uriTemplate`` property to reference the AsyncAPI document (in JSON or YAML) with a URI template. The URI template SHALL include only path parameters that are defined in the OpenAPI description on the path level.
 ====

--- a/standard/sections/clause_7_discovery.adoc
+++ b/standard/sections/clause_7_discovery.adoc
@@ -96,11 +96,23 @@ Given OGC APIs utilize OpenAPI to describe a API, an ``x-ogc-link`` can be made 
 [source,json]
 ----
 {
-    "/collections/discovery-metadata/items": {
+    "/collections/{collectionId}/items": {
+        "parameters": [
+            {
+                "name": "collectionId",
+                "in": "path",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                },
+                "description": "Identifier of the collection"
+            }
+        ],
         "get": {
             "description": "Discovery metadata records",
             "operationId": "getDiscoveryMetadataItems",
-        ...
+
+            ...
         },
         "x-ogc-linkTemplate": {
             "uriTemplate": "https://example.org/asyncapi.json#/channels/{collectionId}"


### PR DESCRIPTION
I think we should make more clear how the templating works. This is just a first proposal, but we should somehow make clear, that the parameters used in the AsyncAPI description somehow have to correspond to the parameters used in the OpenAPI description. E.g. if the resource `/collections/{collectionId}/items` corresponds to the AsyncAPI channel `https://example.org/asyncapi.json#/channels/{collectionId}` we have to make sure, that the two parameters have the same name and schema and that only parameters defined on the path level are used (i.e. `get: {...}` could define a different schema for a path parameter then `post: {...}`)

This PR does not yet address the same-schema part...

