### PR TITLE
remove CloudEvents IANA GitHub issue reference (#27)

### DIFF
--- a/standard/sections/clause_10_media_types.adoc
+++ b/standard/sections/clause_10_media_types.adoc
@@ -39,7 +39,4 @@ A description of the MIME types is mandatory for any OGC API Standard that speci
 |N/A
 |`application/geo+json`
 
-NOTE: media types for CloudEvents payloads are not yet registered with IANA (related discusssion can be found in footnote:[https://github.com/cloudevents/spec/issues/1375]).
-
-
 |===


### PR DESCRIPTION
This PR removes the CloudEvents issue reference to register media types to IANA, given they are [now registered](https://github.com/cloudevents/spec/issues/1375#issuecomment-4440097677).